### PR TITLE
Update for Logger deprecation warning in 1.15

### DIFF
--- a/lib/plug/assign.ex
+++ b/lib/plug/assign.ex
@@ -38,11 +38,11 @@ defmodule Plug.Assign do
         assign(conn, k, v)
 
       {k, _}, conn ->
-        Logger.warn("[Plug.Assign] Invalid key: #{inspect(k)}. Keys must be an atom.")
+        Logger.warning("[Plug.Assign] Invalid key: #{inspect(k)}. Keys must be an atom.")
         conn
 
       var, conn ->
-        Logger.warn(
+        Logger.warning(
           "[Plug.Assign] Invalid assign: #{inspect(var)}. Assigns must be {:key, value}. " <>
             "Use a keyword list or a map with all keys as atoms."
         )

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Plug.Assign.Mixfile do
     [
       app: :plug_assign,
       name: "Plug.Assign",
-      version: "1.0.2",
-      elixir: "~> 1.1",
+      version: "2.0.0",
+      elixir: "~> 1.15.0",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Update for 1.15 deprecation on Logger. 

https://hexdocs.pm/elixir/1.15/changelog.html#integration-with-erlang-otp-logger

To align with erlang logger, warn is changed to warning. Bump mix version major and set minimum elixir version.